### PR TITLE
Guard missing shop menu button

### DIFF
--- a/modules/gui/homeb.lua
+++ b/modules/gui/homeb.lua
@@ -272,8 +272,10 @@ DFRL:NewMod("GUI-Dragonflight", 4, function()
                 UIFrameFadeIn(Base.titleFrame, 0.2, 0, 1)
             end)
 
-            GameMenuButtonShop:ClearAllPoints()
-            GameMenuButtonShop:SetPoint("TOP", self.gamemenuBtn, "BOTTOM", 0, -15)
+            if GameMenuButtonShop then
+                GameMenuButtonShop:ClearAllPoints()
+                GameMenuButtonShop:SetPoint("TOP", self.gamemenuBtn, "BOTTOM", 0, -15)
+            end
 
             GameMenuFrame:SetWidth(GameMenuFrame:GetWidth() + 10)
             GameMenuFrame:SetHeight(GameMenuFrame:GetHeight() + 60)


### PR DESCRIPTION
## Summary
- Guards `GameMenuButtonShop` before repositioning it in the custom game menu.
- Prevents menu setup errors on clients where the shop button frame does not exist.

## Test plan
- Loaded the addon on a client without `GameMenuButtonShop`.
- Opened the Reforged game menu and verified no Lua error occurs.
- Verified behavior remains unchanged when `GameMenuButtonShop` exists.

Fixes #20