### PR TITLE
Remove non-ASCII glyphs from Bars files

### DIFF
--- a/modules/bars/bars.lua
+++ b/modules/bars/bars.lua
@@ -111,7 +111,7 @@ DFRL:NewMod("Bars", 1, function()
             }
         }
 
-        -- ✅ PATCH: Immersion compat helper (não força alpha quando Immersion estiver ativo)
+        -- Immersion compat helper
         local _IsAddOnLoaded = (C_AddOns and C_AddOns.IsAddOnLoaded) or IsAddOnLoaded
         local function DFRL_IsImmersionLoaded()
             return _IsAddOnLoaded and _IsAddOnLoaded("Immersion")
@@ -370,7 +370,7 @@ DFRL:NewMod("Bars", 1, function()
                         _G["ActionButton"..i]:SetAlpha(0)
                         _G["ActionButton"..i]:EnableMouse(false)
                     else
-                        -- ✅ PATCH: não forçar alpha quando Immersion estiver carregado
+                        -- Do not force alpha while Immersion is loaded
                         if not DFRL_IsImmersionLoaded() then
                             _G["ActionButton"..i]:SetAlpha(1)
                         end

--- a/modules/bars/range.lua
+++ b/modules/bars/range.lua
@@ -36,7 +36,7 @@ DFRL:NewMod("RangeIndicator", 1, function()
         if self.useSimple then
             self.indicator = button:CreateFontString(nil, "OVERLAY")
             self.indicator:SetFont("Fonts\\FRIZQT__.TTF", 20, "OUTLINE")
-            self.indicator:SetText("•")
+            self.indicator:SetText("X")
             if self.useDark then
                 self.indicator:SetTextColor(0, 0, 0)
             else


### PR DESCRIPTION
## Summary
- Replaces non-ASCII comments in `bars.lua` with ASCII-only text.
- Replaces the Range Indicator simple marker bullet with an ASCII `X`.
- Improves compatibility with older client and Windows addon setups that can mishandle UTF-8 glyphs.

## Test plan
- Copied the addon to a Windows PC and verified the Bars module loads without encoding issues.
- Verified Range Indicator simple mode still displays a visible marker.

Fixes #22