### PR TITLE
Add Collector exclusion commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ Immersion is developed and maintained by the same author.
 
 <br>
 
+## Collector Commands
+
+The Collector module can exclude minimap buttons from Dragonflight UI: Reforged's minimap button collector.
+
+```text
+/dfrl collector list
+/dfrl collector del <ButtonName>
+/dfrl collector add <ButtonName>
+/dfrl collector reset
+```
+
+Use `list` to show known minimap button names, `del` to release a button back to the minimap, `add` to collect it again, and `reset` to clear all exclusions.
+
+<br>
+
 ## 🛠️ Installation
 
 1. Download the **latest release** of **Dragonflight UI: Reforged**

--- a/modules/gui/homeb.lua
+++ b/modules/gui/homeb.lua
@@ -250,7 +250,28 @@ DFRL:NewMod("GUI-Dragonflight", 4, function()
         end
 
         _G["SLASH_DFRL1"] = "/dfrl"
-        _G.SlashCmdList["DFRL"] = function()
+        _G.SlashCmdList["DFRL"] = function(msg)
+            msg = msg or ""
+            local _, _, command, action, name = string.find(msg, "^(%S+)%s*(%S*)%s*(.*)$")
+            if command == "collector" then
+                if not DFRL.collector then
+                    print("DFRL Collector is not available")
+                elseif action == "list" then
+                    DFRL.collector.List()
+                elseif action == "del" and name ~= "" then
+                    DFRL.collector.Del(name)
+                    print("DFRL Collector excluded: " .. name)
+                elseif action == "add" and name ~= "" then
+                    DFRL.collector.Add(name)
+                    print("DFRL Collector added: " .. name)
+                elseif action == "reset" then
+                    DFRL.collector.Reset()
+                    print("DFRL Collector exclusions reset")
+                else
+                    print("Usage: /dfrl collector list | del <ButtonName> | add <ButtonName> | reset")
+                end
+                return
+            end
             Toggle()
         end
     end

--- a/modules/map/collect.lua
+++ b/modules/map/collect.lua
@@ -1,6 +1,7 @@
 DFRL:NewDefaults("Collector", {
     enabled = { true },
     collectDarkMode = {0, "slider", {0, 1}, nil, "appearance", 1, "Adjust dark mode intensity", nil, nil},
+    excluded = {{}},
 })
 
 DFRL:NewMod("Collector", 1, function()
@@ -14,6 +15,149 @@ DFRL:NewMod("Collector", 1, function()
     }
 
     DFRL.MinimapButtonsPerRow = 3
+
+    function Setup:GetExcluded()
+        local excluded = DFRL:GetTempDB("Collector", "excluded")
+        if type(excluded) ~= "table" then
+            excluded = {}
+            DFRL:SetTempDBNoCallback("Collector", "excluded", excluded)
+        end
+        return excluded
+    end
+
+    function Setup:IsExcluded(name)
+        local excluded = self:GetExcluded()
+        for i = 1, table.getn(excluded) do
+            if excluded[i] == name then
+                return true
+            end
+        end
+        return false
+    end
+
+    function Setup:AddExcluded(name)
+        if not name or name == "" or self:IsExcluded(name) then return end
+        local excluded = self:GetExcluded()
+        table.insert(excluded, name)
+        DFRL:SetTempDBNoCallback("Collector", "excluded", excluded)
+    end
+
+    function Setup:RemoveExcluded(name)
+        local excluded = self:GetExcluded()
+        for i = table.getn(excluded), 1, -1 do
+            if excluded[i] == name then
+                table.remove(excluded, i)
+            end
+        end
+        DFRL:SetTempDBNoCallback("Collector", "excluded", excluded)
+    end
+
+    function Setup:RemoveFromOrder(name)
+        local saved = DFRL:GetTempDB("Collector", "buttonOrder") or {}
+        for i = table.getn(saved), 1, -1 do
+            if saved[i] == name then
+                table.remove(saved, i)
+            end
+        end
+        DFRL:SetTempDBNoCallback("Collector", "buttonOrder", saved)
+
+        for i = table.getn(self.buttonOrder), 1, -1 do
+            local button = self.buttonOrder[i]
+            if button and button:GetName() == name then
+                table.remove(self.buttonOrder, i)
+            end
+        end
+    end
+
+    function Setup:GetDragTarget(button)
+        if not button then return nil end
+        if button:IsObjectType("Button") then return button end
+        if button:IsObjectType("Frame") then
+            local children = {button:GetChildren()}
+            for i = 1, table.getn(children) do
+                if children[i]:IsObjectType("Button") then
+                    return children[i]
+                end
+            end
+        end
+        return button
+    end
+
+    function Setup:SetFallbackPosition(button)
+        button:ClearAllPoints()
+        button:SetFrameStrata("MEDIUM")
+        button:SetPoint("TOPLEFT", Minimap, "BOTTOMLEFT", 0, -8)
+    end
+
+    function Setup:ReleaseButton(button, useFallback)
+        if not button then return end
+        local dragTarget = self:GetDragTarget(button)
+        if dragTarget and dragTarget.dfrlCollectorScripts then
+            dragTarget:SetScript("OnDragStart", dragTarget.dfrlCollectorScripts.OnDragStart)
+            dragTarget:SetScript("OnDragStop", dragTarget.dfrlCollectorScripts.OnDragStop)
+            dragTarget.dfrlCollectorScripts = nil
+        end
+        if dragTarget and dragTarget.UnlockHighlight then
+            dragTarget:UnlockHighlight()
+        end
+        if button.UnlockHighlight then
+            button:UnlockHighlight()
+        end
+        if button.originalSetPoint then
+            button.SetPoint = button.originalSetPoint
+            button.originalSetPoint = nil
+        end
+
+        button:SetParent(Minimap)
+
+        if useFallback then
+            self:SetFallbackPosition(button)
+        end
+        button:Show()
+
+        if useFallback then
+            local releaseFrame = CreateFrame("Frame")
+            releaseFrame:SetScript("OnUpdate", function()
+                releaseFrame:SetScript("OnUpdate", nil)
+                self:SetFallbackPosition(button)
+                button:Show()
+            end)
+        end
+    end
+
+    function Setup:RefreshCollection(includeButton)
+        local buttons = {}
+        local seen = {}
+
+        local function AddButton(button, known)
+            if not button or not button:GetName() or seen[button:GetName()] then return end
+            seen[button:GetName()] = true
+            if self:IsExcluded(button:GetName()) then return end
+            if not known and not self:IsValidButton(button) then return end
+            table.insert(buttons, button)
+        end
+
+        for i = 1, table.getn(self.buttonOrder) do
+            AddButton(self.buttonOrder[i], true)
+        end
+
+        AddButton(includeButton, true)
+
+        local children = { Minimap:GetChildren() }
+        for i = 1, table.getn(children) do
+            AddButton(children[i], false)
+        end
+
+        if table.getn(buttons) == 0 then
+            self.collector:Hide()
+            if DFRL.toggleButton then DFRL.toggleButton:Hide() end
+            self.buttonOrder = {}
+            return
+        end
+        if DFRL.toggleButton then DFRL.toggleButton:Show() end
+        self:ArrangeButtons(buttons)
+        self.collector:Hide()
+    end
 
     function Setup:CleanupFrames()
         KillFrame(_G.MBB_MinimapButtonFrame)
@@ -84,7 +228,9 @@ DFRL:NewMod("Collector", 1, function()
         for i = 1, numChildren do
             local child = children[i]
             if child and self:IsValidButton(child) then
-                table.insert(buttons, child)
+                if not self:IsExcluded(child:GetName()) then
+                    table.insert(buttons, child)
+                end
             end
         end
         return buttons
@@ -101,20 +247,20 @@ DFRL:NewMod("Collector", 1, function()
 
         for i = 1, table.getn(buttons) do
             local button = buttons[i]
+            if not button.originalSetPoint then
+                button.originalSetPoint = button.SetPoint
+                button.SetPoint = function() end
+            end
+
             button:SetParent(self.collector)
             button:ClearAllPoints()
 
             local row = math.floor(count / buttonsPerRow)
             local col = count - (row * buttonsPerRow)
 
-            button:SetPoint("TOPRIGHT", self.collector, "TOPRIGHT",
+            button.originalSetPoint(button, "TOPRIGHT", self.collector, "TOPRIGHT",
                 -3 - (row * (buttonSize + padding)),
                 -6 - (col * (buttonSize + padding)))
-
-            if not button.originalSetPoint then
-                button.originalSetPoint = button.SetPoint
-                button.SetPoint = function() end
-            end
 
             self:EnableDrag(button, i)
 
@@ -235,6 +381,66 @@ DFRL:NewMod("Collector", 1, function()
         DFRL:SetTempDBNoCallback("Collector", "buttonOrder", order)
     end
 
+    function Setup:Exclude(name)
+        local button = _G[name]
+        self:AddExcluded(name)
+        self:RemoveFromOrder(name)
+        if button then
+            self:ReleaseButton(button, true)
+        end
+        self:RefreshCollection()
+    end
+
+    function Setup:Include(name)
+        self:RemoveExcluded(name)
+        self:RefreshCollection(_G[name])
+    end
+
+    function Setup:ResetExcluded()
+        DFRL:SetTempDBNoCallback("Collector", "excluded", {})
+        self:RefreshCollection()
+    end
+
+    function Setup:PrintExcluded()
+        local names = {}
+        local seen = {}
+
+        local function AddName(name)
+            if not name or name == "" or seen[name] then return end
+            seen[name] = true
+            table.insert(names, name)
+        end
+
+        for i = 1, table.getn(self.buttonOrder) do
+            local button = self.buttonOrder[i]
+            if button then AddName(button:GetName()) end
+        end
+
+        local children = { Minimap:GetChildren() }
+        for i = 1, table.getn(children) do
+            local child = children[i]
+            if child and child:GetName() and self:IsValidButton(child) then
+                AddName(child:GetName())
+            end
+        end
+
+        local excluded = self:GetExcluded()
+        for i = 1, table.getn(excluded) do
+            AddName(excluded[i])
+        end
+
+        if table.getn(names) == 0 then
+            print("DFRL Collector: no buttons found")
+            return
+        end
+
+        print("DFRL Collector buttons:")
+        for i = 1, table.getn(names) do
+            local status = self:IsExcluded(names[i]) and "excluded" or "collected"
+            print("  [" .. status .. "] " .. names[i])
+        end
+    end
+
     function Setup:RepositionAllButtons()
         local buttonSize = 24
         local padding = 4
@@ -308,20 +514,19 @@ DFRL:NewMod("Collector", 1, function()
     end
 
     function Setup:EnableDrag(button, index)
-        local dragTarget = button
-        if button:IsObjectType("Frame") then
-            local children = {button:GetChildren()}
-            for i = 1, table.getn(children) do
-                if children[i]:IsObjectType("Button") then
-                    dragTarget = children[i]
-                    break
-                end
-            end
-        end
+        local dragTarget = self:GetDragTarget(button)
+        if not dragTarget then return end
 
         dragTarget:RegisterForDrag("LeftButton")
         button:SetMovable(true)
         dragTarget:EnableMouse(true)
+
+        if not dragTarget.dfrlCollectorScripts then
+            dragTarget.dfrlCollectorScripts = {
+                OnDragStart = dragTarget:GetScript("OnDragStart"),
+                OnDragStop = dragTarget:GetScript("OnDragStop"),
+            }
+        end
 
         dragTarget:SetScript("OnDragStart", function()
             self.dragStartIndex = index
@@ -340,6 +545,11 @@ DFRL:NewMod("Collector", 1, function()
                         currentIndex = i
                         break
                     end
+                end
+
+                if not currentIndex then
+                    self:ReleaseButton(button, true)
+                    return
                 end
 
                 button:ClearAllPoints()
@@ -370,6 +580,13 @@ DFRL:NewMod("Collector", 1, function()
         self:StartDelayedCollection()
         self:AddBorders()
         self:CreateToggleButton()
+
+        DFRL.collector = {
+            List = function() Setup:PrintExcluded() end,
+            Del = function(name) Setup:Exclude(name) end,
+            Add = function(name) Setup:Include(name) end,
+            Reset = function() Setup:ResetExcluded() end,
+        }
     end
 
     Setup:Run()


### PR DESCRIPTION
## Summary
- Adds `/dfrl collector` commands to list, exclude, re-add, and reset minimap button exclusions.
- Persists excluded minimap button names in the Collector settings.
- Releases excluded buttons from Collector ownership and skips them during future scans.
- Documents the new commands in the README.

## Test plan
- Used `/dfrl collector list` to show known minimap buttons.
- Used `/dfrl collector del <ButtonName>` to release a button from the Collector.
- Reloaded the UI and verified the excluded button stayed outside the Collector.
- Used `/dfrl collector add <ButtonName>` to let Collector manage the button again.
- Used `/dfrl collector reset` to clear exclusions.

Fixes #24