### PR TITLE
Handle ShaguTweaks readiness consistently

### DIFF
--- a/core/compat.lua
+++ b/core/compat.lua
@@ -138,36 +138,14 @@ function Setup:ApplyShagu()
         self.fixed.shaguExtras = true
     end
 
-    if ShaguTweaks_config then
-        if not DFRL.gui.shaguCore then
-            DFRL.gui.shaguCoreData = self:ShaguMetaData().core
-            DFRL.gui.shaguCore = true
-        end
+    if not DFRL.gui.shaguCore then
+        DFRL.gui.shaguCoreData = self:ShaguMetaData().core
+        DFRL.gui.shaguCore = true
+    end
 
-        if DFRL.addon2 and not DFRL.gui.shaguExtras then
-            DFRL.gui.shaguExtrasData = self:ShaguMetaData().extras
-            DFRL.gui.shaguExtras = true
-        end
-    else
-        local waitFrame = CreateFrame("Frame")
-        waitFrame.elapsed = 0
-        waitFrame:SetScript("OnUpdate", function()
-            this.elapsed = this.elapsed + arg1
-            if ShaguTweaks_config or this.elapsed > 2 then
-                this:SetScript("OnUpdate", nil)
-                if ShaguTweaks_config then
-                    if not DFRL.gui.shaguCore then
-                        DFRL.gui.shaguCoreData = Setup:ShaguMetaData().core
-                        DFRL.gui.shaguCore = true
-                    end
-
-                    if DFRL.addon2 and not DFRL.gui.shaguExtras then
-                        DFRL.gui.shaguExtrasData = Setup:ShaguMetaData().extras
-                        DFRL.gui.shaguExtras = true
-                    end
-                end
-            end
-        end)
+    if DFRL.addon2 and not DFRL.gui.shaguExtras then
+        DFRL.gui.shaguExtrasData = self:ShaguMetaData().extras
+        DFRL.gui.shaguExtras = true
     end
 end
 
@@ -203,21 +181,19 @@ function Setup:CheckComplete(f)
 end
 
 function Setup:Init()
+    DFRL:OnShaguReady(function()
+        self:ApplyShagu()
+        self.processed["ShaguTweaks"] = true
+    end)
 
     local f = CreateFrame("Frame")
     f:RegisterEvent("ADDON_LOADED")
     f:SetScript("OnEvent", function()
-        if event == "ADDON_LOADED" and self.addons[arg1] then
+        if event == "ADDON_LOADED" and arg1 == "ShaguTweaks-extras" then
             self:HandleAddon(arg1)
             self:CheckComplete(f)
         end
     end)
-
-    if DFRL.addon1 and ShaguTweaks then
-        self:ApplyShagu()
-        self.processed["ShaguTweaks"] = true
-        self:CheckComplete(f)
-    end
 end
 
 Setup:Init()

--- a/core/core.lua
+++ b/core/core.lua
@@ -19,6 +19,14 @@ DFRL.performance = {}
 DFRL.activeScripts = {}
 DFRL.gui = {}
 
+-- ShaguTweaks can load before or after Reforged depending on addon load order.
+DFRL.shagu = {
+    ready = false,
+    configReady = false,
+    callbacks = {},
+    configCallbacks = {},
+}
+
 -- db version
 DFRL.DBversion = "1.0"
 
@@ -45,6 +53,75 @@ function DFRL:GetInfoOrCons(type)
     end
 end
 
+function DFRL:FlushShaguCallbacks(configRequired)
+    local callbacks = configRequired and self.shagu.configCallbacks or self.shagu.callbacks
+    for i = 1, table.getn(callbacks) do
+        callbacks[i]()
+    end
+    if configRequired then
+        self.shagu.configCallbacks = {}
+    else
+        self.shagu.callbacks = {}
+    end
+end
+
+function DFRL:UpdateShaguReady()
+    local ready = ShaguTweaks and ShaguTweaks.T and ShaguTweaks.mods
+    local configReady = ready and ShaguTweaks_config
+
+    if ready or IsAddOnLoaded("ShaguTweaks") then
+        self.addon1 = true
+    end
+    if IsAddOnLoaded("ShaguTweaks-extras") then
+        self.addon2 = true
+    end
+
+    if ready and not self.shagu.ready then
+        self.shagu.ready = true
+        self:FlushShaguCallbacks(false)
+    end
+
+    if configReady and not self.shagu.configReady then
+        self.shagu.configReady = true
+        self:FlushShaguCallbacks(true)
+    end
+end
+
+function DFRL:StartShaguWait()
+    if self.shagu.waitFrame then return end
+
+    local f = CreateFrame("Frame")
+    f.elapsed = 0
+    f:SetScript("OnUpdate", function()
+        this.elapsed = this.elapsed + arg1
+        DFRL:UpdateShaguReady()
+        if (DFRL.shagu.ready and DFRL.shagu.configReady) or this.elapsed > 5 then
+            this:SetScript("OnUpdate", nil)
+            DFRL.shagu.waitFrame = nil
+        end
+    end)
+    self.shagu.waitFrame = f
+end
+
+function DFRL:OnShaguReady(func, configRequired)
+    self:UpdateShaguReady()
+    if configRequired then
+        if self.shagu.configReady then
+            func()
+        else
+            tinsert(self.shagu.configCallbacks, func)
+            self:StartShaguWait()
+        end
+    else
+        if self.shagu.ready then
+            func()
+        else
+            tinsert(self.shagu.callbacks, func)
+            self:StartShaguWait()
+        end
+    end
+end
+
 function DFRL:CheckAddon(name)
     if name == "ShaguTweaks" then
         self.addon1 = true
@@ -68,6 +145,8 @@ function DFRL:CheckAddon(name)
     if IsAddOnLoaded("Immersion") then
         self.addon4 = true
     end
+
+    self:UpdateShaguReady()
 end
 
 function print(msg)
@@ -306,10 +385,14 @@ end
 
 -- init handler
 DFRL:RegisterEvent("ADDON_LOADED")
+DFRL:RegisterEvent("VARIABLES_LOADED")
 DFRL:RegisterEvent("PLAYER_LOGOUT")
 DFRL:SetScript("OnEvent", function()
     if event == "ADDON_LOADED" then
         DFRL:CheckAddon(arg1)
+    end
+    if event == "VARIABLES_LOADED" then
+        DFRL:UpdateShaguReady()
     end
     if event == "ADDON_LOADED" and arg1 == "DragonflightUI-Reforged" then
         if boot then return end

--- a/modules/cast/cast.lua
+++ b/modules/cast/cast.lua
@@ -490,22 +490,10 @@ DFRL:NewMod("Cast", 1, function()
 
     local UnitCastingInfo, UnitChannelInfo
 
-    local function InitShaguTweaks()
-        if ShaguTweaks and ShaguTweaks.UnitCastingInfo then
-            UnitCastingInfo = ShaguTweaks.UnitCastingInfo
-            UnitChannelInfo = ShaguTweaks.UnitChannelInfo
-            return true
-        end
-        return false
-    end
-
-    local f = CreateFrame("Frame")
-    f:RegisterEvent("ADDON_LOADED")
-    f:SetScript("OnEvent", function()
-        if event == "ADDON_LOADED" and arg1 == "ShaguTweaks" then
-            InitShaguTweaks()
-            f:UnregisterEvent("ADDON_LOADED")
-        end
+    -- ShaguTweaks may already be loaded before this module registers events.
+    DFRL:OnShaguReady(function()
+        UnitCastingInfo = ShaguTweaks.UnitCastingInfo
+        UnitChannelInfo = ShaguTweaks.UnitChannelInfo
     end)
 
     Setup:Castbar()

--- a/modules/gui/shag.lua
+++ b/modules/gui/shag.lua
@@ -19,29 +19,16 @@ DFRL:NewMod("Gui-shag", 3, function()
         HEADER_BOTTOM_SPACING = 25,
         CHECKBOX_ROW_SPACING = 45,
         MODULE_SPACING = 25,
+        elementsCreated = false,
     }
 
-    local f = CreateFrame("Frame")
-    f:RegisterEvent("VARIABLES_LOADED")
-    f:SetScript("OnEvent", function()
-        if DFRL.gui.shaguCore == true or DFRL.gui.shaguExtras == true then
-            Setup:MetaData()
-            Setup:Elements()
-        else
-            local waitFrame = CreateFrame("Frame")
-            waitFrame.elapsed = 0
-            waitFrame:SetScript("OnUpdate", function()
-                this.elapsed = this.elapsed + arg1
-                if (DFRL.gui.shaguCore == true or DFRL.gui.shaguExtras == true) or this.elapsed > 3 then
-                    this:SetScript("OnUpdate", nil)
-                    if DFRL.gui.shaguCore == true or DFRL.gui.shaguExtras == true then
-                        Setup:MetaData()
-                        Setup:Elements()
-                    end
-                end
-            end)
-        end
-    end)
+    function Setup:BuildElements()
+        if self.elementsCreated then return end
+        if not DFRL.gui.shaguCoreData and not DFRL.gui.shaguExtrasData then return end
+        self:MetaData()
+        self:Elements()
+        self.elementsCreated = true
+    end
 
     function Setup:MetaData()
         if DFRL.gui.shaguCoreData then
@@ -164,4 +151,9 @@ DFRL:NewMod("Gui-shag", 3, function()
             end
         end
     end
+
+    -- Wait for ShaguTweaks_config so checkboxes can read the saved states.
+    DFRL:OnShaguReady(function()
+        Setup:BuildElements()
+    end, true)
 end)


### PR DESCRIPTION
## Summary

- Add shared ShaguTweaks readiness handling for API-ready and config-ready states.
- Update Shagu-dependent Reforged modules to use the same readiness model.
- Fix load-order cases where ShaguTweaks loads before Reforged modules register their own events.

## Details

ShaguTweaks can load before or after Reforged depending on addon load order and client setup. Previously, different Reforged modules checked for ShaguTweaks readiness in different ways. Some modules could miss the `ADDON_LOADED` event if ShaguTweaks had already loaded, while the GUI could build before `ShaguTweaks_config` was available.

This PR adds a shared readiness helper with two levels:

- Shagu API ready: `ShaguTweaks`, `ShaguTweaks.T`, and `ShaguTweaks.mods` are available
- Shagu config ready: Shagu API is ready and `ShaguTweaks_config` is available

The cast icon and Shagu GUI now use this shared readiness path instead of local timing logic.

## Test plan

- Tested in-game with ShaguTweaks installed.
- Verified the player cast icon appears when "Show Icon" is enabled.
- Verified the Reforged ShaguTweaks panel populates instead of showing only the reload UI button.
- Verified behavior remains stable across reloads during local testing.

Fixes #15